### PR TITLE
feat: Add blue highlighting to version indicator for new announcements (#3)

### DIFF
--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -1837,6 +1837,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 						<VersionIndicator
 							onClick={() => setShowAnnouncementModal(true)}
 							className="absolute top-2 right-3 z-10"
+							hasNewAnnouncement={showAnnouncement}
 						/>
 
 						<RooHero />

--- a/webview-ui/src/components/common/VersionIndicator.tsx
+++ b/webview-ui/src/components/common/VersionIndicator.tsx
@@ -5,15 +5,16 @@ import { Package } from "@roo/package"
 interface VersionIndicatorProps {
 	onClick: () => void
 	className?: string
+	hasNewAnnouncement?: boolean
 }
 
-const VersionIndicator: React.FC<VersionIndicatorProps> = ({ onClick, className = "" }) => {
+const VersionIndicator: React.FC<VersionIndicatorProps> = ({ onClick, className = "", hasNewAnnouncement = false }) => {
 	const { t } = useTranslation()
 
 	return (
 		<button
 			onClick={onClick}
-			className={`text-xs text-vscode-descriptionForeground hover:text-vscode-foreground transition-colors cursor-pointer px-2 py-1 rounded border ${className}`}
+			className={`text-xs ${hasNewAnnouncement ? "text-vscode-button-background hover:text-vscode-button-hoverBackground" : "text-vscode-descriptionForeground hover:text-vscode-foreground"} transition-colors cursor-pointer px-2 py-1 rounded border ${className}`}
 			aria-label={t("chat:versionIndicator.ariaLabel", { version: Package.version })}>
 			v{Package.version}
 		</button>


### PR DESCRIPTION
## Description

Fixes #3

This PR adds visual highlighting to the version indicator when a new announcement is available. When there's a new update with changenotes, the version number appears in blue to draw attention. Clicking the blue version number opens the announcement modal, and the highlighting clears once the modal is viewed.

## Changes Made

### Files Modified:
1. **webview-ui/src/components/common/VersionIndicator.tsx**
   - Added optional `hasNewAnnouncement` prop to component interface
   - Updated styling to conditionally apply blue color when new announcement exists
   - Uses VSCode theme colors: `text-vscode-button-background` for the blue highlight

2. **webview-ui/src/components/chat/ChatView.tsx**
   - Passed `showAnnouncement` prop to VersionIndicator as `hasNewAnnouncement`
   - Connects existing announcement tracking with visual indicator

## How It Works

1. **Detection**: When `lastShownAnnouncementId` doesn't match `latestAnnouncementId` (tracked in ClineProvider.ts), the version appears in blue
2. **User Action**: Clicking the blue version number opens the announcement modal
3. **Clearing**: When modal closes, it updates `lastShownAnnouncementId`, removing the blue highlight

## Testing

- [x] Version indicator displays in blue when new announcement is available
- [x] Clicking version indicator opens announcement modal
- [x] Blue highlighting clears after viewing announcement
- [x] Default gray color when no announcement available
- [x] Hover states work correctly for both states

## Verification of Acceptance Criteria

- [x] Version number appears in blue when new announcement available
- [x] Clicking blue version opens announcement modal with changenotes
- [x] Blue highlighting clears once version indicator is clicked
- [x] Integrates with existing announcement system
- [x] Visual indicator is clear but not obtrusive
- [x] Works with VersionIndicator component in webview-ui

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Uses Tailwind CSS classes with VSCode CSS variables
- [x] No breaking changes
- [x] Minimal, focused implementation